### PR TITLE
Add version flag, tests, and cross-platform storage support

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,0 +1,23 @@
+name: Go CI
+
+on:
+  push:
+    branches: ["*"]
+  pull_request:
+    branches: ["*"]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: 'stable'
+      - name: Format
+        run: gofmt -w $(git ls-files '*.go') && git diff --exit-code
+      - name: Vet
+        run: go vet ./...
+      - name: Test
+        run: go test ./...

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # maclnr
 
-`maclnr` is a command-line tool written in Go that helps you manage directories on macOS by listing and cleaning files. It includes functionality to list files by size and remove `.DS_Store` files.
+`maclnr` is a command-line tool written in Go that helps you manage directories by listing and cleaning files. It includes functionality to list files by size and remove `.DS_Store` files.
 
 ## Installation
 
@@ -108,6 +108,20 @@ The `clean` command removes `.DS_Store` files and files larger than a specified 
 ## License
 
 This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
+
+## Watch Mode
+
+Most commands support a `--watch` flag that refreshes the output every two seconds:
+
+```sh
+./maclnr scan memory --watch
 ```
 
-This updated `README.md` file provides installation instructions, usage examples, and explanations for each command and flag available in the `maclnr` tool, including the new functionality to clean files based on a minimum size recursively.
+## Version
+
+Display the current version with:
+
+```sh
+./maclnr --version
+```
+

--- a/cmd/clean.go
+++ b/cmd/clean.go
@@ -43,27 +43,27 @@ var cleanCmd = &cobra.Command{
 		if err != nil {
 			log.Fatalf("Failed to clean directory: %v\n", err)
 		}
-		fmt.Printf("Successfully cleaned directory: %s\n", dir)
+		fmt.Printf("\033[32mSuccessfully cleaned directory: %s\033[0m\n", dir)
 	},
 }
 
 func cleanDir(dir string, dryRun bool, verbose bool, removeDS bool, minSize int64) error {
 	return filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
-			return err
+			return fmt.Errorf("walking %s: %w", path, err)
 		}
 
 		// Remove .DS_Store files
 		if removeDS && info.Name() == ".DS_Store" {
 			if dryRun {
-				fmt.Printf("[Dry Run] Would remove: %s\n", path)
+				fmt.Printf("\033[33m[Dry Run]\033[0m Would remove: %s\n", path)
 			} else {
 				err := os.Remove(path)
 				if err != nil {
-					return err
+					return fmt.Errorf("removing %s: %w", path, err)
 				}
 				if verbose {
-					fmt.Printf("Removed: %s\n", path)
+					fmt.Printf("\033[32mRemoved: %s\033[0m\n", path)
 				}
 			}
 			return nil
@@ -72,14 +72,14 @@ func cleanDir(dir string, dryRun bool, verbose bool, removeDS bool, minSize int6
 		// Remove files larger than minSize
 		if !info.IsDir() && info.Size() >= minSize {
 			if dryRun {
-				fmt.Printf("[Dry Run] Would remove: %s (%d bytes)\n", path, info.Size())
+				fmt.Printf("\033[33m[Dry Run]\033[0m Would remove: %s (%d bytes)\n", path, info.Size())
 			} else {
 				err := os.Remove(path)
 				if err != nil {
-					return err
+					return fmt.Errorf("removing %s: %w", path, err)
 				}
 				if verbose {
-					fmt.Printf("Removed: %s (%d bytes)\n", path, info.Size())
+					fmt.Printf("\033[32mRemoved: %s (%d bytes)\033[0m\n", path, info.Size())
 				}
 			}
 			return nil

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -59,7 +59,7 @@ var listCmd = &cobra.Command{
 func listFiles(dir string, minSize int64, outputFormat string) error {
 	files, err := listFilesBySize(dir, minSize)
 	if err != nil {
-		return err
+		return fmt.Errorf("listing files in %s: %w", dir, err)
 	}
 
 	switch outputFormat {
@@ -81,7 +81,7 @@ func listFilesBySize(dir string, minSize int64) ([]FileInfo, error) {
 
 	err := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
-			return err
+			return fmt.Errorf("walking %s: %w", path, err)
 		}
 		if !info.IsDir() && info.Size() >= minSize {
 			files = append(files, FileInfo{Path: path, Size: info.Size()})
@@ -89,7 +89,7 @@ func listFilesBySize(dir string, minSize int64) ([]FileInfo, error) {
 		return nil
 	})
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to walk directory %s: %w", dir, err)
 	}
 
 	// Sort files by size in descending order

--- a/cmd/list_test.go
+++ b/cmd/list_test.go
@@ -1,0 +1,36 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestListFilesBySize(t *testing.T) {
+	dir := t.TempDir()
+	paths := []struct {
+		name string
+		size int
+	}{
+		{"small.txt", 10},
+		{"large.txt", 100},
+	}
+	for _, p := range paths {
+		fp := filepath.Join(dir, p.name)
+		content := make([]byte, p.size)
+		if err := os.WriteFile(fp, content, 0644); err != nil {
+			t.Fatalf("write %s: %v", fp, err)
+		}
+	}
+
+	files, err := listFilesBySize(dir, 0)
+	if err != nil {
+		t.Fatalf("listFilesBySize returned error: %v", err)
+	}
+	if len(files) != 2 {
+		t.Fatalf("expected 2 files, got %d", len(files))
+	}
+	if files[0].Size < files[1].Size {
+		t.Fatalf("files not sorted by size")
+	}
+}

--- a/cmd/memory.go
+++ b/cmd/memory.go
@@ -59,7 +59,7 @@ func displayMemoryUsage(outputFormat string) error {
 
 	output, err := cmd.Output()
 	if err != nil {
-		return err
+		return fmt.Errorf("executing %s: %w", cmd.Path, err)
 	}
 
 	if runtime.GOOS == "darwin" {

--- a/cmd/process.go
+++ b/cmd/process.go
@@ -46,7 +46,7 @@ func listProcesses(outputFormat string) error {
 	cmd := exec.Command("ps", "aux")
 	output, err := cmd.Output()
 	if err != nil {
-		return err
+		return fmt.Errorf("executing ps: %w", err)
 	}
 
 	lines := strings.Split(string(output), "\n")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -8,8 +9,14 @@ import (
 
 var rootCmd = &cobra.Command{
 	Use:   "maclnr",
-	Short: "A command-line tool to manage directories on macOS",
+	Short: "A command-line tool to manage directories",
+	Long: `maclnr provides utilities to list large files, clean directories,
+and inspect system information. Most commands support a --watch mode
+for continuous updates.`,
+	Version: version,
 }
+
+var version = "v0.1.0"
 
 func Execute() {
 	if err := rootCmd.Execute(); err != nil {

--- a/cmd/storage.go
+++ b/cmd/storage.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"os"
 	"os/exec"
+	"runtime"
 	"strings"
 	"time"
 
@@ -45,33 +46,63 @@ var storageCmd = &cobra.Command{
 }
 
 func listStorageDevices(outputFormat string) error {
-	cmd := exec.Command("diskutil", "list")
+	var cmd *exec.Cmd
+	if runtime.GOOS == "darwin" {
+		cmd = exec.Command("diskutil", "list")
+	} else if runtime.GOOS == "linux" {
+		cmd = exec.Command("lsblk", "-o", "NAME,FSTYPE,SIZE,MOUNTPOINT")
+	} else {
+		return fmt.Errorf("unsupported platform")
+	}
 	output, err := cmd.Output()
 	if err != nil {
-		return err
+		return fmt.Errorf("executing %s: %w", cmd.Path, err)
 	}
 
 	var devices []map[string]string
 	scanner := bufio.NewScanner(strings.NewReader(string(output)))
-	var currentDevice map[string]string
 
-	for scanner.Scan() {
-		line := scanner.Text()
-		if strings.HasPrefix(line, "/dev/") {
-			if currentDevice != nil {
-				devices = append(devices, currentDevice)
+	if runtime.GOOS == "darwin" {
+		var currentDevice map[string]string
+		for scanner.Scan() {
+			line := scanner.Text()
+			if strings.HasPrefix(line, "/dev/") {
+				if currentDevice != nil {
+					devices = append(devices, currentDevice)
+				}
+				currentDevice = map[string]string{"Identifier": line}
+			} else if strings.Contains(line, "GUID_partition_scheme") || strings.Contains(line, "FDisk_partition_scheme") || strings.Contains(line, "Apple_partition_scheme") {
+				currentDevice["Type"] = line
+			} else if strings.Contains(line, " (disk") {
+				parts := strings.Split(line, " ")
+				currentDevice["Name"] = strings.Join(parts[:len(parts)-1], " ")
+				currentDevice["Size"] = parts[len(parts)-1]
 			}
-			currentDevice = map[string]string{"Identifier": line}
-		} else if strings.Contains(line, "GUID_partition_scheme") || strings.Contains(line, "FDisk_partition_scheme") || strings.Contains(line, "Apple_partition_scheme") {
-			currentDevice["Type"] = line
-		} else if strings.Contains(line, " (disk") {
-			parts := strings.Split(line, " ")
-			currentDevice["Name"] = strings.Join(parts[:len(parts)-1], " ")
-			currentDevice["Size"] = parts[len(parts)-1]
 		}
-	}
-	if currentDevice != nil {
-		devices = append(devices, currentDevice)
+		if currentDevice != nil {
+			devices = append(devices, currentDevice)
+		}
+	} else {
+		// linux lsblk output parsing
+		var headers []string
+		for scanner.Scan() {
+			line := strings.TrimSpace(scanner.Text())
+			if line == "" {
+				continue
+			}
+			fields := strings.Fields(line)
+			if headers == nil {
+				headers = fields
+				continue
+			}
+			device := make(map[string]string)
+			for i, h := range headers {
+				if i < len(fields) {
+					device[h] = fields[i]
+				}
+			}
+			devices = append(devices, device)
+		}
 	}
 
 	switch outputFormat {


### PR DESCRIPTION
## Summary
- add `--version` and extended descriptions
- color output for clean command
- handle errors with wrapped context
- support Linux in `storage` command
- include test for listing files
- document watch mode and version
- set up basic GitHub Actions workflow

## Testing
- `go test ./...` *(fails: Forbidden - no internet)*

------
https://chatgpt.com/codex/tasks/task_e_68602ddd8138832d8548c47bbf1f789a